### PR TITLE
Pipeline optimisation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,15 @@ jobs:
           steps:
             - run: npm ci
             - run: npm test
+  validate:
+    executor:
+      name: node/default
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm ls
+            - run: npm test
   release:
     executor:
       name: node/default
@@ -25,6 +34,7 @@ workflows:
   test-release:
     jobs:
       - test
+      - validate
       - release:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,15 +11,6 @@ jobs:
           steps:
             - run: npm ci
             - run: npm test
-  validate:
-    executor:
-      name: node/default
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm ls
-            - run: npm test
   release:
     executor:
       name: node/default
@@ -27,14 +18,12 @@ jobs:
       - checkout
       - node/with-cache:
           steps:
-            - run: npm ci
             - run: npm run build
             - run: npm run release
 workflows:
   test-release:
     jobs:
       - test
-      - validate
       - release:
           filters:
             branches:


### PR DESCRIPTION
The release stage in the pipeline is running `npm ci`. This command deletes the existing `node_modules` folder which means it is not leveraging the CircleCI caching functionality.