### PR TITLE
🧹 Simplify string padding with padEnd

### DIFF
--- a/src/encode.ts
+++ b/src/encode.ts
@@ -30,16 +30,8 @@ class SectionBuilder {
       value = field;
     }
 
-    let valueLength = value.length;
-
     if (length !== undefined) {
-      if (valueLength > length) {
-        value = value.substring(0, length);
-      } else if (valueLength < length) {
-        for (let i = 0; i < length - valueLength; i++) {
-          value += " ";
-        }
-      }
+      value = value.substring(0, length).padEnd(length, " ");
     }
 
     this.output.push(value);


### PR DESCRIPTION
🎯 **What:** Simplified the manual string truncation and spacing loop in `src/encode.ts` by replacing it with a combination of `.substring()` and `.padEnd()`.
💡 **Why:** `String.prototype.padEnd()` is a standard built-in method that provides a more concise and declarative way to handle string padding compared to a custom loop.
✅ **Verification:** Ran `npm test` and all existing unit tests in the codebase pass. The refactored code correctly handles strings that are longer (truncation), exactly the same length, or shorter (padding with spaces) than the specified `length`.
✨ **Result:** A more readable and maintainable codebase without introducing any behavior changes.

---
*PR created automatically by Jules for task [739874014061359266](https://jules.google.com/task/739874014061359266) started by @georgesmith46*