### PR TITLE
ci: enable npm provenance via OIDC in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # to be able to publish a GitHub release
+      issues: write # to be able to comment on released issues
+      pull-requests: write # to be able to comment on released pull requests
+      id-token: write # to enable use of OIDC for npm provenance
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,5 +34,5 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true
         run: npm run release


### PR DESCRIPTION
Fixes the failing release pipeline by switching from the expired NPM token to tokenless OIDC publishing with NPM Trusted Connections (provenance).

---
*PR created automatically by Jules for task [697043906920752844](https://jules.google.com/task/697043906920752844) started by @georgesmith46*